### PR TITLE
Add Makefile and Mongo setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+.PHONY: install-mongo init-db
+
+install-mongo:
+	@echo "Installing MongoDB (Debian/Ubuntu example)"
+	sudo apt-get update && sudo apt-get install -y mongodb
+
+init-db:
+        @echo "Starting MongoDB using docker-compose"
+        docker-compose up -d

--- a/README.md
+++ b/README.md
@@ -16,3 +16,15 @@ This starts an HTTP server on `:8080` with the following endpoints:
 - `GET  /todos` – list all todos
 
 
+
+## Development Helpers
+
+The repository includes a `Makefile` and a `docker-compose.yaml` file to set up a local MongoDB instance with some seed data.
+
+```bash
+# Build and run MongoDB with sample data
+make init-db
+```
+
+This uses the official MongoDB Docker image through Docker Compose and executes `scripts/init-db.js` on startup. The `install-mongo` target demonstrates how MongoDB can be installed on Debian/Ubuntu based systems.
+

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,9 @@
+version: '3.8'
+services:
+  mongo:
+    image: mongo:7.0
+    container_name: todos-mongo
+    ports:
+      - "27017:27017"
+    volumes:
+      - ./scripts/init-db.js:/docker-entrypoint-initdb.d/init-db.js:ro

--- a/scripts/init-db.js
+++ b/scripts/init-db.js
@@ -1,0 +1,4 @@
+db = db.getSiblingDB('todos');
+db.createCollection('todos');
+db.todos.insertOne({ title: 'Welcome', description: 'Sample todo item' });
+


### PR DESCRIPTION
## Summary
- add a Makefile with targets to install MongoDB and start a dockerized instance
- create an initialization script for Mongo
- add Dockerfile using the official Mongo image
- document new helpers in README

## Testing
- `go vet ./...` *(fails: no route to host)*